### PR TITLE
Report in Step Summary

### DIFF
--- a/.github/workflows/test_vacuum.yaml
+++ b/.github/workflows/test_vacuum.yaml
@@ -22,6 +22,7 @@ jobs:
           fail_on_error: true
           minimum_score: 80
           print_logs: false
+          step_summary: false
           openapi_path: "sample-specs/burgershop.yaml"
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -32,6 +33,7 @@ jobs:
           fail_on_error: true
           minimum_score: 80
           print_logs: true
+          step_summary: true
           ruleset: "sample-specs/ruleset.yaml"
           openapi_path: "sample-specs/burgershop.yaml"
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Here are the configurable properties you can use in your workflow:
 | `fail_on_error`  | `boolean` | _false_  | If set to `true`, the action will fail if any errors are detected in the OpenAPI spec. Defaults to `true`                      |
 | `minimum_score`  | `number`  | _false_  | The minimum score required to not fail the check. Defaults to `70`.                                                            |
 | `print_logs`     | `boolean` | _false_  | If set to `true`, the action will print the markdown report to the runner logs. Defaults to `true`                             |
+| `step_summary`   | `boolean` | _false_  | If set to `true`, the action will add the markdown report to the step summary. Defaults to `true`                              |
 
 ---
 
@@ -88,5 +89,6 @@ jobs:
           fail_on_error: true
           minimum_score: 90
           print_logs: true
+          step_summary: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,10 @@ inputs:
     description: "Print the markdown report out to runner logs (defaults to 'true')"
     required: false
     default: "true"
-
+  step_summary:
+    description: "Add the markdown report to the github step summary"
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -38,46 +41,50 @@ runs:
       shell: bash
       run: |
         args=( lint --pipeline-output "${{ inputs.openapi_path }}" )
-        
+
         # --min-score <value>
         args+=( --min-score "${{ inputs.minimum_score }}" )
-        
+
         # --fail-severity none|error
         if [ "${{ inputs.fail_on_error }}" = "true" ]; then
           args+=( --fail-severity error )
         else
           args+=( --fail-severity none )
         fi
-        
+
         # --show-rules only if show_rules == "true"
         if [ "${{ inputs.show_rules }}" = "true" ]; then
           args+=( --show-rules )
         fi
-        
+
         # optional ruleset
         if [ -n "${{ inputs.ruleset }}" ]; then
           args+=( --ruleset "${{ inputs.ruleset }}" )
         fi
-        
+
         CMD=( docker run --rm \
                -v "$GITHUB_WORKSPACE":/work:ro \
                dshanley/vacuum "${args[@]}" )
-        
+
         echo "Running: ${CMD[*]}"
         report=$("${CMD[@]}")
-        
+
         REPORT_FILE="$GITHUB_WORKSPACE/vacuum-lint-report.md"
         {
           echo "<!-- vacuum-lint-report -->"
           echo
           echo "$report"
         } > "$REPORT_FILE"
-        
+
         # print logs to console if enabled
         if [ "${{ inputs.print_logs }}" = "true" ]; then
           cat "$REPORT_FILE"
         fi
-        
+
+        if [ "${{ inputs.step_summary }}" = "true" ]; then
+          cat "$REPORT_FILE" >> $GITHUB_STEP_SUMMARY
+        fi
+
         echo "report_path=vacuum-lint-report.md" >> "$GITHUB_OUTPUT"
       env:
         DOCKER_BUILDKIT: 1
@@ -87,9 +94,8 @@ runs:
       uses: peter-evans/find-comment@v3
       with:
         issue-number: ${{ github.event.pull_request.number }}
-        comment-author: 'github-actions[bot]'
+        comment-author: "github-actions[bot]"
         body-includes: "<!-- vacuum-lint-report -->"
-
 
     - name: Create or update vacuum-lint comment
       if: always()
@@ -101,7 +107,3 @@ runs:
         comment-id: ${{ steps.find-comment.outputs.comment-id }}
         body-path: ${{ steps.lint.outputs.report_path }}
         edit-mode: replace
-
-
-
-

--- a/action.yml
+++ b/action.yml
@@ -41,50 +41,50 @@ runs:
       shell: bash
       run: |
         args=( lint --pipeline-output "${{ inputs.openapi_path }}" )
-
+        
         # --min-score <value>
         args+=( --min-score "${{ inputs.minimum_score }}" )
-
+        
         # --fail-severity none|error
         if [ "${{ inputs.fail_on_error }}" = "true" ]; then
           args+=( --fail-severity error )
         else
           args+=( --fail-severity none )
         fi
-
+        
         # --show-rules only if show_rules == "true"
         if [ "${{ inputs.show_rules }}" = "true" ]; then
           args+=( --show-rules )
         fi
-
+        
         # optional ruleset
         if [ -n "${{ inputs.ruleset }}" ]; then
           args+=( --ruleset "${{ inputs.ruleset }}" )
         fi
-
+        
         CMD=( docker run --rm \
                -v "$GITHUB_WORKSPACE":/work:ro \
                dshanley/vacuum "${args[@]}" )
-
+        
         echo "Running: ${CMD[*]}"
         report=$("${CMD[@]}")
-
+        
         REPORT_FILE="$GITHUB_WORKSPACE/vacuum-lint-report.md"
         {
           echo "<!-- vacuum-lint-report -->"
           echo
           echo "$report"
         } > "$REPORT_FILE"
-
+        
         # print logs to console if enabled
         if [ "${{ inputs.print_logs }}" = "true" ]; then
           cat "$REPORT_FILE"
         fi
-
+        
         if [ "${{ inputs.step_summary }}" = "true" ]; then
           cat "$REPORT_FILE" >> $GITHUB_STEP_SUMMARY
         fi
-
+        
         echo "report_path=vacuum-lint-report.md" >> "$GITHUB_OUTPUT"
       env:
         DOCKER_BUILDKIT: 1
@@ -94,8 +94,9 @@ runs:
       uses: peter-evans/find-comment@v3
       with:
         issue-number: ${{ github.event.pull_request.number }}
-        comment-author: "github-actions[bot]"
+        comment-author: 'github-actions[bot]'
         body-includes: "<!-- vacuum-lint-report -->"
+
 
     - name: Create or update vacuum-lint comment
       if: always()
@@ -107,3 +108,7 @@ runs:
         comment-id: ${{ steps.find-comment.outputs.comment-id }}
         body-path: ${{ steps.lint.outputs.report_path }}
         edit-mode: replace
+
+
+
+


### PR DESCRIPTION
Hey - thanks for this project

This PR adds support for storing the report in the [GitHub job summary](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#adding-a-job-summary).

<img width="1295" height="854" alt="screenshot" src="https://github.com/user-attachments/assets/8edd9204-808e-47ca-9e6f-eafcd5255d87" />

You can check an example here: https://github.com/x-delfino/vacuum-action/actions/runs/22102868661

it's on by default but I can change that if needed

I *think* this partly resolves #7, but I'm not sure if that issue is also asking for something to be reported when the linter fails to run

it would also make sense now to have a toggle for disabling PR comments, I'm going to raise that in another PR because it also makes sense to check if it was actually triggered by a PR before trying to comment on it (I think there are a couple of other issues about that)