### PR TITLE
Make Comments Optional

### DIFF
--- a/.github/workflows/test_vacuum.yaml
+++ b/.github/workflows/test_vacuum.yaml
@@ -22,7 +22,6 @@ jobs:
           fail_on_error: true
           minimum_score: 80
           print_logs: false
-          post_comment: false
           openapi_path: "sample-specs/burgershop.yaml"
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -33,7 +32,6 @@ jobs:
           fail_on_error: true
           minimum_score: 80
           print_logs: true
-          post_comment: false
           ruleset: "sample-specs/ruleset.yaml"
           openapi_path: "sample-specs/burgershop.yaml"
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_vacuum.yaml
+++ b/.github/workflows/test_vacuum.yaml
@@ -22,6 +22,7 @@ jobs:
           fail_on_error: true
           minimum_score: 80
           print_logs: false
+          post_comment: false
           openapi_path: "sample-specs/burgershop.yaml"
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -32,6 +33,7 @@ jobs:
           fail_on_error: true
           minimum_score: 80
           print_logs: true
+          post_comment: true
           ruleset: "sample-specs/ruleset.yaml"
           openapi_path: "sample-specs/burgershop.yaml"
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_vacuum.yaml
+++ b/.github/workflows/test_vacuum.yaml
@@ -22,6 +22,7 @@ jobs:
           fail_on_error: true
           minimum_score: 80
           print_logs: false
+          post_comment: false
           openapi_path: "sample-specs/burgershop.yaml"
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -32,6 +33,7 @@ jobs:
           fail_on_error: true
           minimum_score: 80
           print_logs: true
+          post_comment: false
           ruleset: "sample-specs/ruleset.yaml"
           openapi_path: "sample-specs/burgershop.yaml"
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Here are the configurable properties you can use in your workflow:
 | `fail_on_error`  | `boolean` | _false_  | If set to `true`, the action will fail if any errors are detected in the OpenAPI spec. Defaults to `true`                      |
 | `minimum_score`  | `number`  | _false_  | The minimum score required to not fail the check. Defaults to `70`.                                                            |
 | `print_logs`     | `boolean` | _false_  | If set to `true`, the action will print the markdown report to the runner logs. Defaults to `true`                             |
+| `post_comment`   | `boolean` | _false_  | If set to `true`, the action will post the markdown report to a comment on the PR. Defaults to `true`                          |
 
 ---
 
@@ -88,5 +89,6 @@ jobs:
           fail_on_error: true
           minimum_score: 90
           print_logs: true
+          post_comment: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: "Print the markdown report out to runner logs (defaults to 'true')"
     required: false
     default: "true"
+  post_comment:
+    description: "Post comment to PR (skipped if action was not triggered by PR)"
+    required: false
+    default: "true"
 
 
 runs:
@@ -84,6 +88,8 @@ runs:
 
     - name: Find existing vacuum-lint comment (if any)
       id: find-comment
+      if: ${{ github.event_name == 'pull_request' && inputs.post_comment == 'true' }}
+      continue-on-error: true
       uses: peter-evans/find-comment@v3
       with:
         issue-number: ${{ github.event.pull_request.number }}
@@ -92,7 +98,7 @@ runs:
 
 
     - name: Create or update vacuum-lint comment
-      if: always()
+      if: ${{ github.event_name == 'pull_request' && inputs.post_comment == 'true' }}
       uses: peter-evans/create-or-update-comment@v4
       with:
         token: ${{ inputs.github_token }}


### PR DESCRIPTION
Hey

This PR:
  - adds an input `post_comment` to control whether comments are posted on PRs
  - disables PR comment automatically if the action was not triggered by a PR
  
This should resolve #6 and resolve #9
 
 I'm not sure the best way of adding tests for this (hence my messy PR earlier). The problem is that comments don't have a unique identifier and so a single step with multiple runs of vacuum will overwrite the same comment (mentioned in #5)