### PR TITLE
Handle failed linting

### DIFF
--- a/.github/workflows/test_vacuum_failed.yaml
+++ b/.github/workflows/test_vacuum_failed.yaml
@@ -1,0 +1,27 @@
+name: "Lint OpenAPI specification using vacuum (failing task)"
+
+on:
+  pull_request: {}
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  vacuum-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Run OpenAPI lint with vacuum and custom ruleset
+        uses: ./
+        with:
+          show_rules: true
+          fail_on_error: true
+          minimum_score: 100
+          print_logs: true
+          ruleset: "sample-specs/ruleset.yaml"
+          openapi_path: "sample-specs/burgershop.yaml"
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,11 @@ runs:
                dshanley/vacuum "${args[@]}" )
         
         echo "Running: ${CMD[*]}"
+        set +e
         report=$("${CMD[@]}")
+        EXIT_CODE=$?
+        set -e
+        echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
         
         REPORT_FILE="$GITHUB_WORKSPACE/vacuum-lint-report.md"
         {
@@ -92,7 +96,6 @@ runs:
 
 
     - name: Create or update vacuum-lint comment
-      if: always()
       uses: peter-evans/create-or-update-comment@v4
       with:
         token: ${{ inputs.github_token }}
@@ -103,5 +106,9 @@ runs:
         edit-mode: replace
 
 
+    - name: Passthrough linter exit code
+      shell: bash
+      run: |
+        exit ${{ steps.lint.outputs.exit_code }}
 
 


### PR DESCRIPTION
Currently if the linting scores under the value specified in `minimum_score`, the task would fail without posting any of the results

This PR patches that behaviour by capturing the exit code and returning it at the end

This means we can get nice comments like below if the linting fails

<img width="885" height="631" alt="Screenshot" src="https://github.com/user-attachments/assets/dabd90fc-4dc5-4932-814d-c9487dae09c8" />

I've added in an example to test this - this is expected to fail, not sure if there's a better way you want this handled?

what I haven't done much about, is what happens if the linting fails for some other reason? maybe could throw an error if the exit code isn't 0 and nothing was received in `report`

fixes #8