### PR TITLE
Make PR comments optional via post_comment input

### DIFF
--- a/.github/workflows/test_vacuum.yaml
+++ b/.github/workflows/test_vacuum.yaml
@@ -22,6 +22,7 @@ jobs:
           fail_on_error: true
           minimum_score: 80
           print_logs: false
+          post_comment: false
           openapi_path: "sample-specs/burgershop.yaml"
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -32,6 +33,7 @@ jobs:
           fail_on_error: true
           minimum_score: 80
           print_logs: true
+          post_comment: true
           ruleset: "sample-specs/ruleset.yaml"
           openapi_path: "sample-specs/burgershop.yaml"
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Here are the configurable properties you can use in your workflow:
 | `minimum_score`  | `number`  | _false_  | The minimum score required to not fail the check. Defaults to `70`.                                                            |
 | `print_logs`     | `boolean` | _false_  | If set to `true`, the action will print the markdown report to the runner logs. Defaults to `true`                             |
 | `vacuum_version` | `string`  | _false_  | The vacuum Docker image tag to use. Defaults to `latest`.                                                                      |
+| `post_comment`   | `boolean` | _false_  | If set to `true`, the action will post the markdown report to a comment on the PR. Skipped automatically if the action was not triggered by a PR. Defaults to `true`. |
 
 ---
 
@@ -89,6 +90,7 @@ jobs:
           fail_on_error: true
           minimum_score: 90
           print_logs: true
+          post_comment: true
           vacuum_version: "v0.23.2"
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: "Vacuum Docker image tag to use (default: latest)"
     required: false
     default: "latest"
+  post_comment:
+    description: "Post comment to PR (skipped if action was not triggered by PR)"
+    required: false
+    default: "true"
 
 
 runs:
@@ -88,6 +92,8 @@ runs:
 
     - name: Find existing vacuum-lint comment (if any)
       id: find-comment
+      if: ${{ github.event_name == 'pull_request' && inputs.post_comment == 'true' }}
+      continue-on-error: true
       uses: peter-evans/find-comment@v3
       with:
         issue-number: ${{ github.event.pull_request.number }}
@@ -96,7 +102,7 @@ runs:
 
 
     - name: Create or update vacuum-lint comment
-      if: always()
+      if: ${{ github.event_name == 'pull_request' && inputs.post_comment == 'true' }}
       uses: peter-evans/create-or-update-comment@v4
       with:
         token: ${{ inputs.github_token }}


### PR DESCRIPTION
This adds a `post_comment` input (default `true`) and gates the comment steps so the action no longer fails when it is **not** triggered by a pull request (e.g. on `push`).

### What changed
- New `post_comment` input (default `"true"`).
- Both comment steps now run only when `github.event_name == 'pull_request' && inputs.post_comment == 'true'`.
- The *Find existing comment* step gets `continue-on-error: true` so a lookup failure never fails the job.
- README table + example and the test workflow updated accordingly.

This is the same behavior proposed in #13, rebased cleanly onto current `main` (which has since added `vacuum_version` — no overlap/conflicts).

Resolves #6, resolves #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
