### PR TITLE
fix: support globbed openapi paths and preserve PR reports

### DIFF
--- a/.github/workflows/test_vacuum.yaml
+++ b/.github/workflows/test_vacuum.yaml
@@ -8,12 +8,12 @@ permissions:
   pull-requests: write
 
 jobs:
-  vacuum-lint:
+  vacuum-lint-success:
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run OpenAPI lint with vacuum
         uses: ./
@@ -22,8 +22,21 @@ jobs:
           fail_on_error: true
           minimum_score: 80
           print_logs: false
-          openapi_path: "sample-specs/burgershop.yaml"
+          openapi_path: "sample-specs/*shop.{yaml,yml}"
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Assert globbed lint report covers both sample specs
+        shell: bash
+        run: |
+          if ! grep -q 'sample-specs/burgershop.yaml' vacuum-lint-report.md; then
+            echo "Expected burgershop spec to appear in the report." >&2
+            exit 1
+          fi
+
+          if ! grep -q 'sample-specs/frieshop.yaml' vacuum-lint-report.md; then
+            echo "Expected frieshop spec to appear in the report." >&2
+            exit 1
+          fi
 
       - name: Run OpenAPI lint with vacuum and custom ruleset
         uses: ./
@@ -35,3 +48,75 @@ jobs:
           ruleset: "sample-specs/ruleset.yaml"
           openapi_path: "sample-specs/burgershop.yaml"
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  vacuum-lint-failure-report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run OpenAPI lint with a failing minimum score
+        id: failing-lint
+        continue-on-error: true
+        uses: ./
+        with:
+          fail_on_error: true
+          minimum_score: 101
+          print_logs: false
+          openapi_path: "sample-specs/*shop.{yaml,yml}"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Assert failing lint still produced a report
+        shell: bash
+        run: |
+          if [ "${{ steps.failing-lint.outcome }}" != "failure" ]; then
+            echo "Expected the lint step to fail." >&2
+            exit 1
+          fi
+
+          if [ ! -s vacuum-lint-report.md ]; then
+            echo "Expected vacuum-lint-report.md to exist and be non-empty." >&2
+            exit 1
+          fi
+
+          if ! grep -q '<!-- vacuum-lint-report -->' vacuum-lint-report.md; then
+            echo "Expected the report marker to be present." >&2
+            exit 1
+          fi
+
+          if ! grep -q '^## \[vacuum\]' vacuum-lint-report.md; then
+            echo "Expected the markdown report header to be present." >&2
+            exit 1
+          fi
+
+  vacuum-lint-no-match:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run OpenAPI lint with a non-matching glob
+        id: no-match
+        continue-on-error: true
+        uses: ./
+        with:
+          fail_on_error: true
+          minimum_score: 80
+          print_logs: false
+          openapi_path: "sample-specs/does-not-exist.{yaml,yml}"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Assert a non-matching glob fails before report creation
+        shell: bash
+        run: |
+          if [ "${{ steps.no-match.outcome }}" != "failure" ]; then
+            echo "Expected the no-match lint step to fail." >&2
+            exit 1
+          fi
+
+          if [ -e vacuum-lint-report.md ]; then
+            echo "Did not expect a report file when no OpenAPI files matched." >&2
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ All you need to do is add the action to your repo via a workflow via `pb33f/vacu
 
 Here are the configurable properties you can use in your workflow:
 
-| Property         | Type      | Required | Description                                                                                                                    |
-|------------------|-----------|----------|--------------------------------------------------------------------------------------------------------------------------------|
-| `openapi_path`   | `string`  | **true** | The path to your OpenAPI spec file, relative to the root of your repository.                                                   |
-| `github_token`   | `string`  | **true** | The GitHub token to use for authentication. This is required to post comments on pull requests.                                |
-| `ruleset`        | `string`  | _false_  | The path to a custom ruleset file, relative to the root of your repository. If not provided, the default ruleset will be used. | 
-| `show_rules`     | `boolean` | _false_  | If set to `true`, the action will show the rules that were applied. Defaults to `false`                                        |
-| `fail_on_error`  | `boolean` | _false_  | If set to `true`, the action will fail if any errors are detected in the OpenAPI spec. Defaults to `true`                      |
-| `minimum_score`  | `number`  | _false_  | The minimum score required to not fail the check. Defaults to `70`.                                                            |
-| `print_logs`     | `boolean` | _false_  | If set to `true`, the action will print the markdown report to the runner logs. Defaults to `true`                             |
-| `vacuum_version` | `string`  | _false_  | The vacuum Docker image tag to use. Defaults to `latest`.                                                                      |
+| Property         | Type      | Required | Description                                                                                                                                                  |
+|------------------|-----------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `openapi_path`   | `string`  | **true** | The path or glob pattern for your OpenAPI spec file(s), relative to the root of your repository. Brace patterns such as `specs/*.{yaml,yml}` are supported.  |
+| `github_token`   | `string`  | **true** | The GitHub token to use for authentication. This is required to post comments on pull requests.                                                              |
+| `ruleset`        | `string`  | _false_  | The path to a custom ruleset file, relative to the root of your repository. If not provided, the default ruleset will be used.                               | 
+| `show_rules`     | `boolean` | _false_  | If set to `true`, the action will show the rules that were applied. Defaults to `false`                                                                      |
+| `fail_on_error`  | `boolean` | _false_  | If set to `true`, the action will fail if any errors are detected in the OpenAPI spec. Defaults to `true`                                                    |
+| `minimum_score`  | `number`  | _false_  | The minimum score required to not fail the check. Defaults to `70`.                                                                                          |
+| `print_logs`     | `boolean` | _false_  | If set to `true`, the action will print the markdown report to the runner logs. Defaults to `true`                                                           |
+| `vacuum_version` | `string`  | _false_  | The vacuum Docker image tag to use. Defaults to `latest`.                                                                                                    |
 
 ---
 
@@ -83,7 +83,7 @@ jobs:
       - name: Run OpenAPI lint with vacuum
         uses: pb33f/vacuum-action@v2
         with:
-          openapi_path: "specs/openapi.yaml"
+          openapi_path: "specs/*.{yaml,yml}"
           ruleset: "rulesets/vacuum-ruleset.yaml"
           show_rules: true
           fail_on_error: true
@@ -92,3 +92,5 @@ jobs:
           vacuum_version: "v0.23.2"
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+Pull request comments are created or updated only for pull request events. On other events, the action still lints and fails the job when vacuum reports a failure.

--- a/action.yml
+++ b/action.yml
@@ -105,7 +105,7 @@ runs:
 
     - name: Find existing vacuum-lint comment (if any)
       id: find-comment
-      if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+      if: github.event.pull_request != null
       uses: peter-evans/find-comment@v3
       with:
         issue-number: ${{ github.event.pull_request.number }}
@@ -114,7 +114,7 @@ runs:
 
 
     - name: Create or update vacuum-lint comment
-      if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.lint.outputs.has_report == 'true' }}
+      if: always() && github.event.pull_request != null && steps.lint.outputs.has_report == 'true'
       uses: peter-evans/create-or-update-comment@v4
       with:
         token: ${{ inputs.github_token }}

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: "Lint and quality check an OpenAPI specification using vacuum, the 
 
 inputs:
   openapi_path:
-    description: "Path to the OpenAPI spec file (relative to repo root, e.g., 'specs/openapi.yaml')"
+    description: "Path or glob pattern for OpenAPI spec files (relative to repo root, e.g., 'specs/openapi.yaml' or 'specs/*.{yaml,yml}')"
     required: true
   show_rules:
     description: "Show the rules that were applied (default: false)"
@@ -41,7 +41,9 @@ runs:
       id: lint
       shell: bash
       run: |
-        args=( lint --pipeline-output "${{ inputs.openapi_path }}" )
+        set -euo pipefail
+
+        args=( lint --pipeline-output --globbed-files "$INPUT_OPENAPI_PATH" )
         
         # --min-score <value>
         args+=( --min-score "${{ inputs.minimum_score }}" )
@@ -68,13 +70,21 @@ runs:
                "dshanley/vacuum:${{ inputs.vacuum_version }}" "${args[@]}" )
         
         echo "Running: ${CMD[*]}"
+        set +e
         report=$("${CMD[@]}")
+        lint_exit_code=$?
+        set -e
+
+        report_body=$(printf '%s\n' "$report" | awk 'seen || /^#/{seen=1; print}')
+        if [ -z "$report_body" ]; then
+          report_body="$report"
+        fi
         
         REPORT_FILE="$GITHUB_WORKSPACE/vacuum-lint-report.md"
         {
           echo "<!-- vacuum-lint-report -->"
           echo
-          echo "$report"
+          printf '%s\n' "$report_body"
         } > "$REPORT_FILE"
         
         # print logs to console if enabled
@@ -83,11 +93,19 @@ runs:
         fi
         
         echo "report_path=vacuum-lint-report.md" >> "$GITHUB_OUTPUT"
+        echo "lint_exit_code=$lint_exit_code" >> "$GITHUB_OUTPUT"
+        if [ -n "$report_body" ]; then
+          echo "has_report=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "has_report=false" >> "$GITHUB_OUTPUT"
+        fi
       env:
         DOCKER_BUILDKIT: 1
+        INPUT_OPENAPI_PATH: ${{ inputs.openapi_path }}
 
     - name: Find existing vacuum-lint comment (if any)
       id: find-comment
+      if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
       uses: peter-evans/find-comment@v3
       with:
         issue-number: ${{ github.event.pull_request.number }}
@@ -96,7 +114,7 @@ runs:
 
 
     - name: Create or update vacuum-lint comment
-      if: always()
+      if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.lint.outputs.has_report == 'true' }}
       uses: peter-evans/create-or-update-comment@v4
       with:
         token: ${{ inputs.github_token }}
@@ -105,6 +123,13 @@ runs:
         comment-id: ${{ steps.find-comment.outputs.comment-id }}
         body-path: ${{ steps.lint.outputs.report_path }}
         edit-mode: replace
+
+    - name: Fail action if vacuum lint failed
+      if: ${{ steps.lint.outputs.lint_exit_code != '0' }}
+      shell: bash
+      run: |
+        echo "vacuum lint failed with exit code ${{ steps.lint.outputs.lint_exit_code }}." >&2
+        exit 1
 
 
 

--- a/sample-specs/frieshop.yaml
+++ b/sample-specs/frieshop.yaml
@@ -1,0 +1,135 @@
+openapi: 3.1.0
+info:
+  title: Fry Shop
+  description: |
+    A small sample API for listing fries and sauces.
+  termsOfService: https://quobix.com
+  contact:
+    name: quobix
+  license:
+    name: Quobix
+  version: "1.0"
+tags:
+  - name: Fries
+    description: Crispy potato products.
+  - name: Sauces
+    description: Dips for fries.
+servers:
+  - url: https://quobix.com/api
+paths:
+  /fries:
+    get:
+      operationId: listFries
+      tags:
+        - Fries
+      summary: List fries
+      description: Return all fries currently available on the menu.
+      responses:
+        "200":
+          description: A list of fries.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Fry'
+              examples:
+                default:
+                  summary: Classic fries
+                  value:
+                    - id: regular-fries
+                      name: Regular Fries
+                      salted: true
+        "500":
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                unexpectedError:
+                  summary: Fry failure
+                  value:
+                    message: something went terribly wrong retrieving fries.
+  /sauces/{sauceId}:
+    get:
+      operationId: getSauce
+      tags:
+        - Sauces
+      summary: Get sauce by ID
+      description: Return one sauce for dipping fries.
+      parameters:
+        - in: path
+          name: sauceId
+          required: true
+          description: The sauce identifier.
+          schema:
+            type: string
+          example: aioli
+      responses:
+        "200":
+          description: A sauce for your fries.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sauce'
+              examples:
+                default:
+                  summary: Garlic aioli
+                  value:
+                    id: aioli
+                    name: Garlic Aioli
+                    spicy: false
+        "404":
+          description: Sauce not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                notFound:
+                  summary: Missing sauce
+                  value:
+                    message: no sauce found for that identifier.
+components:
+  schemas:
+    Fry:
+      type: object
+      required:
+        - id
+        - name
+        - salted
+      properties:
+        id:
+          type: string
+          example: regular-fries
+        name:
+          type: string
+          example: Regular Fries
+        salted:
+          type: boolean
+          example: true
+    Sauce:
+      type: object
+      required:
+        - id
+        - name
+        - spicy
+      properties:
+        id:
+          type: string
+          example: aioli
+        name:
+          type: string
+          example: Garlic Aioli
+        spicy:
+          type: boolean
+          example: false
+    Error:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          example: something went terribly wrong.


### PR DESCRIPTION
## Summary

- add glob support for `openapi_path` via vacuum's native `--globbed-files` flag, including brace patterns such as `specs/*.{yaml,yml}`
- preserve the generated markdown report and defer failure until after PR comment handling
- only run the comment lookup/update steps for pull request events
- document the new input behavior and exercise it in the sample workflow
- add frieshop.yaml as a second fixture to exercise multi-file glob matching
- add .gitignore

## Testing

Three CI jobs cover the key scenarios end-to-end:

- **`vacuum-lint-success`** — lints both sample specs via `*shop.{yaml,yml}` and asserts both appear in the report
- **`vacuum-lint-failure-report`** — uses `minimum_score: 101` to force failure and asserts the report file is still written and well-formed
- **`vacuum-lint-no-match`** — uses a non-existent glob and asserts the action fails before producing any report file